### PR TITLE
Add WiiLoad feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,226 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### VirtualEnv template
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+pip-selfcheck.json

--- a/gui/ui_united.py
+++ b/gui/ui_united.py
@@ -8,11 +8,9 @@
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
 
-from PySide2.QtCore import (QCoreApplication, QDate, QDateTime, QMetaObject,
-    QObject, QPoint, QRect, QSize, QTime, QUrl, Qt)
-from PySide2.QtGui import (QBrush, QColor, QConicalGradient, QCursor, QFont,
-    QFontDatabase, QIcon, QKeySequence, QLinearGradient, QPalette, QPainter,
-    QPixmap, QRadialGradient)
+from PySide2.QtCore import (QCoreApplication, QMetaObject,
+                            QRect, QSize, Qt)
+from PySide2.QtGui import (QFont)
 from PySide2.QtWidgets import *
 
 
@@ -66,7 +64,7 @@ class Ui_MainWindow(object):
         self.ExtractAppCheckbox.setGeometry(QRect(10, 260, 179, 17))
         self.progressBar = QProgressBar(self.SelectionInfoBox)
         self.progressBar.setObjectName(u"progressBar")
-        self.progressBar.setGeometry(QRect(170, 310, 91, 23))
+        self.progressBar.setGeometry(QRect(180, 250, 91, 23))
         self.progressBar.setValue(0)
         self.tabMetadata = QTabWidget(self.SelectionInfoBox)
         self.tabMetadata.setObjectName(u"tabMetadata")
@@ -75,7 +73,7 @@ class Ui_MainWindow(object):
         self.GeneralTab.setObjectName(u"GeneralTab")
         self.formLayoutWidget = QWidget(self.GeneralTab)
         self.formLayoutWidget.setObjectName(u"formLayoutWidget")
-        self.formLayoutWidget.setGeometry(QRect(10, 60, 221, 126))
+        self.formLayoutWidget.setGeometry(QRect(10, 60, 221, 166))
         self.MetaLayout = QFormLayout(self.formLayoutWidget)
         self.MetaLayout.setObjectName(u"MetaLayout")
         self.MetaLayout.setContentsMargins(0, 0, 0, 0)
@@ -181,12 +179,9 @@ class Ui_MainWindow(object):
         self.metaTreeWidget.setGeometry(QRect(10, 10, 221, 121))
         self.metaTreeWidget.setRootIsDecorated(False)
         self.tabMetadata.addTab(self.RawTab, "")
-        self.ViewMetadataBtn = QPushButton(self.SelectionInfoBox)
-        self.ViewMetadataBtn.setObjectName(u"ViewMetadataBtn")
-        self.ViewMetadataBtn.setGeometry(QRect(10, 310, 149, 23))
         self.formLayoutWidget_2 = QWidget(self.SelectionInfoBox)
         self.formLayoutWidget_2.setObjectName(u"formLayoutWidget_2")
-        self.formLayoutWidget_2.setGeometry(QRect(10, 280, 251, 22))
+        self.formLayoutWidget_2.setGeometry(QRect(10, 280, 251, 31))
         self.MetaLayout_2 = QFormLayout(self.formLayoutWidget_2)
         self.MetaLayout_2.setObjectName(u"MetaLayout_2")
         self.MetaLayout_2.setContentsMargins(0, 0, 0, 0)
@@ -200,10 +195,26 @@ class Ui_MainWindow(object):
 
         self.MetaLayout_2.setWidget(0, QFormLayout.FieldRole, self.FileNameLineEdit)
 
+        self.horizontalLayoutWidget = QWidget(self.SelectionInfoBox)
+        self.horizontalLayoutWidget.setObjectName(u"horizontalLayoutWidget")
+        self.horizontalLayoutWidget.setGeometry(QRect(10, 310, 251, 30))
+        self.horizontalLayout = QHBoxLayout(self.horizontalLayoutWidget)
+        self.horizontalLayout.setObjectName(u"horizontalLayout")
+        self.horizontalLayout.setContentsMargins(0, 0, 0, 0)
+        self.ViewMetadataBtn = QPushButton(self.horizontalLayoutWidget)
+        self.ViewMetadataBtn.setObjectName(u"ViewMetadataBtn")
+
+        self.horizontalLayout.addWidget(self.ViewMetadataBtn)
+
+        self.WiiLoadButton = QPushButton(self.horizontalLayoutWidget)
+        self.WiiLoadButton.setObjectName(u"WiiLoadButton")
+
+        self.horizontalLayout.addWidget(self.WiiLoadButton)
+
         MainWindow.setCentralWidget(self.centralwidget)
         self.menubar = QMenuBar(MainWindow)
         self.menubar.setObjectName(u"menubar")
-        self.menubar.setGeometry(QRect(0, 0, 900, 21))
+        self.menubar.setGeometry(QRect(0, 0, 900, 25))
         self.menuAbout = QMenu(self.menubar)
         self.menuAbout.setObjectName(u"menuAbout")
         self.menuExport = QMenu(self.menubar)
@@ -255,21 +266,26 @@ class Ui_MainWindow(object):
         self.label_description.setText(QCoreApplication.translate("MainWindow", u"Description", None))
         self.label_displayname.setText(QCoreApplication.translate("MainWindow", u"Title", None))
         self.tabMetadata.setTabText(self.tabMetadata.indexOf(self.GeneralTab), QCoreApplication.translate("MainWindow", u"General", None))
-        self.longDescriptionBrowser.setHtml(QCoreApplication.translate("MainWindow", u"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><br /></p></body></html>", None))
+        self.longDescriptionBrowser.setHtml(QCoreApplication.translate("MainWindow",
+                                                                       u"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"
+                                                                       "<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">\n"
+                                                                       "p, li { white-space: pre-wrap; }\n"
+                                                                       "</style></head><body style=\" font-family:'Cantarell'; font-size:10pt; font-weight:400; font-style:normal;\">\n"
+                                                                       "<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8.25pt;\"><br /></p></body></html>",
+                                                                       None))
         self.LongDescLabel.setText(QCoreApplication.translate("MainWindow", u"Long Description", None))
-        self.tabMetadata.setTabText(self.tabMetadata.indexOf(self.Description), QCoreApplication.translate("MainWindow", u"Long Description", None))
+        self.tabMetadata.setTabText(self.tabMetadata.indexOf(self.Description),
+                                    QCoreApplication.translate("MainWindow", u"Long Description", None))
         self.DirectLinkLabel.setText(QCoreApplication.translate("MainWindow", u"Direct Link", None))
         self.CopyDirectLinkBtn.setText(QCoreApplication.translate("MainWindow", u"Copy", None))
         ___qtreewidgetitem = self.metaTreeWidget.headerItem()
         ___qtreewidgetitem.setText(1, QCoreApplication.translate("MainWindow", u"Value", None));
         ___qtreewidgetitem.setText(0, QCoreApplication.translate("MainWindow", u"Type", None));
-        self.tabMetadata.setTabText(self.tabMetadata.indexOf(self.RawTab), QCoreApplication.translate("MainWindow", u"Raw", None))
-        self.ViewMetadataBtn.setText(QCoreApplication.translate("MainWindow", u"Download App", None))
+        self.tabMetadata.setTabText(self.tabMetadata.indexOf(self.RawTab),
+                                    QCoreApplication.translate("MainWindow", u"Raw", None))
         self.FileNameLabel.setText(QCoreApplication.translate("MainWindow", u"Output File", None))
+        self.ViewMetadataBtn.setText(QCoreApplication.translate("MainWindow", u"Download", None))
+        self.WiiLoadButton.setText(QCoreApplication.translate("MainWindow", u"WiiLoad", None))
         self.menuAbout.setTitle(QCoreApplication.translate("MainWindow", u"About", None))
         self.menuExport.setTitle(QCoreApplication.translate("MainWindow", u"Export Data", None))
         self.menuApplication_List.setTitle(QCoreApplication.translate("MainWindow", u"Application List", None))

--- a/gui/united.ui
+++ b/gui/united.ui
@@ -154,8 +154,8 @@
     <widget class="QProgressBar" name="progressBar">
      <property name="geometry">
       <rect>
-       <x>170</x>
-       <y>310</y>
+       <x>180</x>
+       <y>250</y>
        <width>91</width>
        <height>23</height>
       </rect>
@@ -186,7 +186,7 @@
          <x>10</x>
          <y>60</y>
          <width>221</width>
-         <height>126</height>
+         <height>166</height>
         </rect>
        </property>
        <layout class="QFormLayout" name="MetaLayout">
@@ -352,10 +352,14 @@
        </property>
        <property name="html">
         <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+         p, li { white-space: pre-wrap; }
+         &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:10pt; font-weight:400;
+         font-style:normal;&quot;&gt;
+         &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px;
+         margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8.25pt;&quot;&gt;&lt;br
+         /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+        </string>
        </property>
       </widget>
       <widget class="QLabel" name="LongDescLabel">
@@ -440,26 +444,13 @@ p, li { white-space: pre-wrap; }
       </widget>
      </widget>
     </widget>
-    <widget class="QPushButton" name="ViewMetadataBtn">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>310</y>
-       <width>149</width>
-       <height>23</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Download App</string>
-     </property>
-    </widget>
     <widget class="QWidget" name="formLayoutWidget_2">
      <property name="geometry">
       <rect>
        <x>10</x>
        <y>280</y>
        <width>251</width>
-       <height>22</height>
+       <height>31</height>
       </rect>
      </property>
      <layout class="QFormLayout" name="MetaLayout_2">
@@ -475,6 +466,32 @@ p, li { white-space: pre-wrap; }
       </item>
      </layout>
     </widget>
+    <widget class="QWidget" name="horizontalLayoutWidget">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>310</y>
+       <width>251</width>
+       <height>30</height>
+      </rect>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QPushButton" name="ViewMetadataBtn">
+        <property name="text">
+         <string>Download</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="WiiLoadButton">
+        <property name="text">
+         <string>WiiLoad</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </widget>
   </widget>
   <widget class="QMenuBar" name="menubar">
@@ -483,7 +500,7 @@ p, li { white-space: pre-wrap; }
      <x>0</x>
      <y>0</y>
      <width>900</width>
-     <height>21</height>
+     <height>25</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuAbout">

--- a/xosc_dl.py
+++ b/xosc_dl.py
@@ -46,7 +46,6 @@ class MainWindow(gui.ui_united.Ui_MainWindow, QMainWindow):
         self.ui.statusBar.showMessage(message)
 
     def populate(self):
-        self.ui.ViewMetadataBtn.clicked.connect(self.view_metadata)
         self.ui.CopyDirectLinkBtn.clicked.connect(self.copy_download_link_button)
         self.ui.RefreshListBtn.clicked.connect(self.repopulate)
         self.ui.ReposComboBox.currentIndexChanged.connect(self.changed_host)

--- a/xosc_dl.py
+++ b/xosc_dl.py
@@ -1,14 +1,15 @@
-import metadata
-import download
-import parsecontents
-import gui.ui_united
-import updater
-import pyperclip
 import io
 import re
 from contextlib import redirect_stdout
+
+import pyperclip
 from PySide2.QtWidgets import QApplication, QMainWindow
 
+import download
+import gui.ui_united
+import metadata
+import parsecontents
+import updater
 
 version = updater.current_version()
 host = "hbb1.oscwii.org"

--- a/xosc_dl.py
+++ b/xosc_dl.py
@@ -150,7 +150,7 @@ class MainWindow(gui.ui_united.Ui_MainWindow, QMainWindow):
         r = requests.get(url)
 
         self.status_message("Preparing app...")
-        self.ui.progressBar.setValue(50)
+        self.ui.progressBar.setValue(40)
 
         zipped_app = io.BytesIO(r.content)
         zip_file = zipfile.ZipFile(zipped_app, mode='r')
@@ -197,9 +197,10 @@ class MainWindow(gui.ui_united.Ui_MainWindow, QMainWindow):
 
         # connecting
         self.status_message('Connecting to the HBC...')
+        self.ui.progressBar.setValue(50)
 
         conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        conn.settimeout(5)
+        conn.settimeout(2)
         try:
             conn.connect((ip, 4299))
         except socket.error as e:

--- a/xosc_dl.py
+++ b/xosc_dl.py
@@ -54,6 +54,7 @@ class MainWindow(gui.ui_united.Ui_MainWindow, QMainWindow):
 
     def populate_meta(self):
         self.ui.ViewMetadataBtn.clicked.connect(self.download_button)
+        self.ui.WiiLoadButton.clicked.connect(self.wiiload_button)
 
         self.ui.listAppsWidget.currentItemChanged.connect(self.selection_changed)
 
@@ -111,6 +112,9 @@ class MainWindow(gui.ui_united.Ui_MainWindow, QMainWindow):
             download.get(app_name=self.app_name, repo=host, output=output, extract=extract)
         self.ui.progressBar.setValue(100)
         self.status_message(escape_ansi(console_output.getvalue()))
+
+    def wiiload_button(self):
+        print('h')
 
     def copy_download_link_button(self):
         self.app_name = self.ui.listAppsWidget.currentItem().text()

--- a/xosc_dl.py
+++ b/xosc_dl.py
@@ -18,10 +18,10 @@ import metadata
 import parsecontents
 import updater
 
-version = updater.current_version()
-host = "hbb1.oscwii.org"
+VERSION = updater.current_version()
+HOST = "hbb1.oscwii.org"
 
-ip_regex = re.compile(r"^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$")
+IP_REGEX = re.compile(r"^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$")
 
 # WiiLoad
 WIILOAD_VER_MAJOR = 0
@@ -46,7 +46,7 @@ class MainWindow(gui.ui_united.Ui_MainWindow, QMainWindow):
         super(MainWindow, self).__init__()
         self.ui = gui.ui_united.Ui_MainWindow()
         self.ui.setupUi(self)
-        self.setWindowTitle("Open Shop Channel Downloader v"+version+" - Library")
+        self.setWindowTitle("Open Shop Channel Downloader v" + VERSION + " - Library")
         self.populate()
         self.populate_meta()
         self.selection_changed()
@@ -63,7 +63,7 @@ class MainWindow(gui.ui_united.Ui_MainWindow, QMainWindow):
         self.ui.CopyDirectLinkBtn.clicked.connect(self.copy_download_link_button)
         self.ui.RefreshListBtn.clicked.connect(self.repopulate)
         self.ui.ReposComboBox.currentIndexChanged.connect(self.changed_host)
-        self.ui.actionAbout_OSC_DL.setText("osc-dl Version v" + version)
+        self.ui.actionAbout_OSC_DL.setText("osc-dl Version v" + VERSION)
         self.populate_list()
 
     def populate_meta(self):
@@ -78,7 +78,7 @@ class MainWindow(gui.ui_united.Ui_MainWindow, QMainWindow):
         except Exception:
             app_name = None
         if app_name is not None:
-            info = metadata.dictionary(app_name, repo=host)
+            info = metadata.dictionary(app_name, repo=HOST)
             self.ui.appname.setText(info.get("display_name"))
             self.ui.SelectionInfoBox.setTitle("Metadata: " + info.get("display_name"))
             self.ui.label_displayname.setText(info.get("display_name"))
@@ -92,7 +92,7 @@ class MainWindow(gui.ui_united.Ui_MainWindow, QMainWindow):
                 self.ui.label_description.setText(info.get("short_description"))
             self.ui.longDescriptionBrowser.setText(info.get("long_description"))
             self.ui.FileNameLineEdit.setText(app_name + ".zip")
-            self.ui.DirectLinkLineEdit.setText(metadata.url(app_name, repo=host))
+            self.ui.DirectLinkLineEdit.setText(metadata.url(app_name, repo=HOST))
         self.ui.progressBar.setValue(0)
         self.status_message("Ready to download")
 
@@ -123,7 +123,7 @@ class MainWindow(gui.ui_united.Ui_MainWindow, QMainWindow):
         self.ui.progressBar.setValue(25)
         console_output = io.StringIO()
         with redirect_stdout(console_output):
-            download.get(app_name=self.app_name, repo=host, output=output, extract=extract)
+            download.get(app_name=self.app_name, repo=HOST, output=output, extract=extract)
         self.ui.progressBar.setValue(100)
         self.status_message(escape_ansi(console_output.getvalue()))
 
@@ -134,7 +134,7 @@ class MainWindow(gui.ui_united.Ui_MainWindow, QMainWindow):
         if not ok:
             return
 
-        ip_match = ip_regex.match(ip)
+        ip_match = IP_REGEX.match(ip)
         if not ip_match:
             QMessageBox.warning(self, 'Invalid IP Address', 'This IP address is invalid.')
 
@@ -146,7 +146,7 @@ class MainWindow(gui.ui_united.Ui_MainWindow, QMainWindow):
 
         # download.get() cannot save to our own file-like object.
         # Alt fix: add a file parameter to write to instead?
-        url = f"https://{host}/hbb/{self.app_name}/{self.app_name}.zip"
+        url = f"https://{HOST}/hbb/{self.app_name}/{self.app_name}.zip"
         r = requests.get(url)
 
         self.status_message("Preparing app...")
@@ -235,13 +235,13 @@ class MainWindow(gui.ui_united.Ui_MainWindow, QMainWindow):
 
     def copy_download_link_button(self):
         self.app_name = self.ui.listAppsWidget.currentItem().text()
-        pyperclip.copy(metadata.url(self.app_name, repo=host))
+        pyperclip.copy(metadata.url(self.app_name, repo=HOST))
         self.status_message("Copied the download link for " + self.app_name + " to clipboard")
 
     def changed_host(self):
-        global host
-        host = get_repo_host(self.ui.ReposComboBox.currentText())
-        self.status_message("Loading " + host + " repository..")
+        global HOST
+        HOST = get_repo_host(self.ui.ReposComboBox.currentText())
+        self.status_message("Loading " + HOST + " repository..")
         self.ui.progressBar.setValue(20)
         self.repopulate()
 
@@ -252,7 +252,7 @@ class MainWindow(gui.ui_united.Ui_MainWindow, QMainWindow):
         self.ui.progressBar.setValue(100)
 
     def populate_list(self):
-        self.applist = parsecontents.list(repo=host)
+        self.applist = parsecontents.list(repo=HOST)
         for item in self.applist:
             self.ui.listAppsWidget.addItem(item)
         self.ui.listAppsWidget.setCurrentRow(0)


### PR DESCRIPTION
This PR adds a button next to the download button that allows the user to remotely install the app on their Wii by using WiiLoad to transmit the files to the HBC.

I also made some small modifications to the existing code:
* Global variables are now UPPER CASE
* Imports are now grouped
* I added a .gitignore file containing rules for Python, JetBrains IDEs and virtual envs.

**Screenshots:**
[![https://imgur.com/884ytub.png](https://imgur.com/884ytub.png)](https://imgur.com/884ytub.png)
[![https://imgur.com/IsWYMr1.png](https://imgur.com/IsWYMr1.png)](https://imgur.com/IsWYMr1.png)
[![https://imgur.com/2XseUUh.png](https://imgur.com/2XseUUhl.png)](https://imgur.com/2XseUUhl.png)