### PR TITLE
[WiiLoad] Allow extra directories/files to be sent.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -12,7 +12,7 @@ def is_test(name):
         return False
 
 
-def is_supported_by_wiiload(package):
+def app_has_extra_directories(package):
     # remove all directories under /apps
     root_directories = []
     for directory in package["extra_directories"]:

--- a/wiiload.py
+++ b/wiiload.py
@@ -56,7 +56,7 @@ def organize_zip(zipped_app, zip_buf):
             # Just in case there is a rouge README file.
             if f"{dirname}../../read".upper() in new_path.upper():
                 READMEFile = new_path.split(".")[-2]
-                new_path = new_path.replace(READMEFile,f'{READMEFile}_{appname}',)
+                new_path = new_path.replace(READMEFile,f'{READMEFile}_{appname}')
                 
         if not new_path:
             continue
@@ -79,11 +79,11 @@ def organize_zip(zipped_app, zip_buf):
     # NOTE: HBC will delete all 0 byte files and dot files.
     for x in app_zip.filelist:
         if x.is_dir():
-             with app_zip.open(x.filename+'._OSCDL',"w") as temp: 
+             with app_zip.open(x.filename+'._OSCDL', 'w') as temp: 
                 temp.write("This file can be deleted.".encode("utf-8"))
         elif x.file_size == 0:
-            with app_zip.open(x.filename,"w") as temp: 
-                temp.write(".".encode("utf-8"))
+            with app_zip.open(x.filename, 'w') as temp: 
+                temp.write('.'.encode("utf-8"))
     # cleanup
     zipped_app.close()
     zip_file.close()

--- a/wiiload.py
+++ b/wiiload.py
@@ -53,7 +53,7 @@ def organize_zip(zipped_app, zip_buf):
             # However, HBC does not check for relative directories.
             # By stepping back two directories, we are at the root of the SD/USB.
             new_path = dirname + "../../" + info.filename 
-            # Just in case there is a rouge README file.
+            # Just in case there is a rogue README file.
             if f"{dirname}../../read".upper() in new_path.upper():
                 READMEFile = new_path.split(".")[-2]
                 new_path = new_path.replace(READMEFile,f'{READMEFile}_{appname}')

--- a/wiiload.py
+++ b/wiiload.py
@@ -79,7 +79,7 @@ def organize_zip(zipped_app, zip_buf):
     # NOTE: HBC will delete all 0 byte files and dot files.
     for x in app_zip.filelist:
         if x.is_dir():
-             with app_zip.open(x.filename+'._OSCDL', 'w') as temp: 
+            with app_zip.open(x.filename+'._OSCDL', 'w') as temp: 
                 temp.write("This file can be deleted.".encode("utf-8"))
         elif x.file_size == 0:
             with app_zip.open(x.filename, 'w') as temp: 

--- a/wiiload.py
+++ b/wiiload.py
@@ -26,12 +26,38 @@ def organize_zip(zipped_app, zip_buf):
     app_infolist = zip_file.infolist()
 
     # Our zip file should only contain one directory with the app data in it,
-    # but the downloaded file contains an apps/ directory. We're removing that here.
+    # but it will be kept, as long is it's relative to the root of the SD/USB. 
+    # This creates a zip file based on relative directories to extract all files.
     app_zip = zipfile.ZipFile(zip_buf, mode='w', compression=zipfile.ZIP_DEFLATED)
 
-    # copy over all files
+    # Zip manipulation time.
+    # First we need the directory name of the app.
+    dirname = ""
+    appname = ""
     for info in app_infolist:
-        new_path = info.filename.replace('apps/', '')
+        if 'apps/' in info.filename and info.filename != 'apps/':
+            appname = info.filename.split("/")[1]
+            dirname = appname+"/"
+            break
+
+    # Copy over all files
+    # In HBC, the app is directly written at the apps directory.
+    # The app's name MUST be the first directory name in apps.
+    # HBC will check for consistant directory names, 
+    # if one does not match, it gives the "Unusable zip" error.
+    # This means we need the app's directory first.
+    for info in app_infolist:
+        if 'apps/' in info.filename:
+            new_path = info.filename.replace('apps/', '')
+        else:
+            # However, HBC does not check for relative directories.
+            # By stepping back two directories, we are at the root of the SD/USB.
+            new_path = dirname + "../../" + info.filename 
+            # Just in case there is a rouge README file.
+            if f"{dirname}../../read".upper() in new_path.upper():
+                READMEFile = new_path.split(".")[-2]
+                new_path = new_path.replace(READMEFile,f'{READMEFile}_{appname}',)
+                
         if not new_path:
             continue
 
@@ -41,14 +67,23 @@ def organize_zip(zipped_app, zip_buf):
         new_info = copy.copy(info)
         new_info.filename = new_path
 
-        if new_info.filename[-1] in ('/', '\\'):  # directory
-            continue
-
         with zip_file.open(info.filename, 'r') as file:
             data = file.read()
 
         app_zip.writestr(new_path, data)
 
+    # Finally, if a directory is empty, HBC will not write it.
+    # So, this adds a dot file to all directories, regardless of contents.
+    # HBC will delete that file, but not the directory.
+    # Addtionally, if a file is 0 bytes, add something to it.
+    # NOTE: HBC will delete all 0 byte files and dot files.
+    for x in app_zip.filelist:
+        if x.is_dir():
+             with app_zip.open(x.filename+'._OSCDL',"w") as temp: 
+                temp.write("This file can be deleted.".encode("utf-8"))
+        elif x.file_size == 0:
+            with app_zip.open(x.filename,"w") as temp: 
+                temp.write(".".encode("utf-8"))
     # cleanup
     zipped_app.close()
     zip_file.close()

--- a/xosc_dl.py
+++ b/xosc_dl.py
@@ -258,13 +258,9 @@ class MainWindow(gui.ui_united.Ui_MainWindow, QMainWindow):
             # Clear supported controllers listview:
             self.ui.SupportedControllersListWidget.clear()
 
-            # check if send to wii is supported
-            if utils.is_supported_by_wiiload(self.current_app):
-                self.ui.WiiLoadButton.setEnabled(True)
-                self.ui.WiiLoadButton.setText("Send to Wii")
-            else:
-                self.ui.WiiLoadButton.setEnabled(False)
-                self.ui.WiiLoadButton.setText("Send Not Supported")
+            # Enable Send to Wii button
+            self.ui.WiiLoadButton.setEnabled(True)
+            self.ui.WiiLoadButton.setText("Send to Wii")
 
             # -- Get actual metadata
             # App Name
@@ -474,11 +470,14 @@ class MainWindow(gui.ui_united.Ui_MainWindow, QMainWindow):
         :param state: bool
         """
         self.ui.ViewMetadataBtn.setDisabled(state)
-        self.ui.WiiLoadButton.setDisabled(state or not utils.is_supported_by_wiiload(self.current_app))
+        self.ui.WiiLoadButton.setDisabled(state)
         self.ui.ReposComboBox.setDisabled(state)
         self.ui.listAppsWidget.setDisabled(state)
 
     def wiiload_button(self):
+        if not utils.app_has_extra_directories(self.current_app) and QMessageBox.question(self, "Send to Wii", "This app contains extra files and directories that may need configuration. Send anyway?") == QMessageBox.StandardButton.No:
+            return
+        
         dialog = WiiLoadDialog(self.current_app, parent=self)
         status = dialog.exec()
         if not status:


### PR DESCRIPTION
After examining the source code of HBC, I was able to implement a method to include additional files and folders in a zip formatted for WiiLoad. (Should solve issue #37)
It is accomplished by relative directories starting from the app's directory folder, then moving to the root of the SD card or USB Drive. 

I have tested the following with good success: 
* WiiSXRX
* Wii7800
* Wiimmfi Patcher

Additional fixes:
* ```utils.is_supported_by_wiiload()``` is now ```utils.app_has_extra_directories()```
* The code to disable the Send to Wii button is now removed, since this PR should fix the compatibility. 
* If there are extra directories, question box will appear which will ask: "This app contains extra files and directories that may need configuration. Send anyway?"



