### PR TITLE
Change timeout to 200

### DIFF
--- a/wiiload.py
+++ b/wiiload.py
@@ -109,7 +109,7 @@ def prepare(zip_buf):
 
 def connect(ip):
     conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    conn.settimeout(2)
+    conn.settimeout(200)
     conn.connect((ip, 4299))
     return conn
 


### PR DESCRIPTION
The default timeout of 2 does not give HBC enough time to receive the app as it will time out while sending the app. Changing the timeout to 200 fixes this. 